### PR TITLE
Remove auto trigger

### DIFF
--- a/src/main/scala/com/typesafe/sbt/SbtMultiJvm.scala
+++ b/src/main/scala/com/typesafe/sbt/SbtMultiJvm.scala
@@ -73,8 +73,6 @@ object MultiJvmPlugin extends AutoPlugin {
 
   import MultiJvmKeys._
 
-  override def trigger = allRequirements
-
   override def requires = plugins.JvmPlugin
 
   override def projectSettings = multiJvmSettings


### PR DESCRIPTION
Attention: That's a breaking change and requires a new minor version (0.4), because one has to explicitly enable the `MultiJvmPlugin` now. The reason for this change is that in a multi-module build usually only some modules use this plugin and explicitly enabling is preferred about disabling.