### PR TITLE
update assembly

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -9,7 +9,7 @@ bintrayOrganization := Some("sbt-multi-jvm")
 publishMavenStyle := false
 licenses += ("Apache-2.0", url("https://www.apache.org/licenses/LICENSE-2.0.html"))
 
-addSbtPlugin("com.eed3si9n" % "sbt-assembly" % "0.13.0")
+addSbtPlugin("com.eed3si9n" % "sbt-assembly" % "0.14.3")
 
 scalacOptions ++= List(
   "-unchecked",


### PR DESCRIPTION
Otherwise the plugin will blow up with incompatibilities when the build it's being used in included the `0.14.3` version.

There's no real tests in this project so I'm not sure this change is not breaking something... :<
