### PR TITLE
Configure Scala Steward to not update Scala minor version

### DIFF
--- a/.scala-steward.conf
+++ b/.scala-steward.conf
@@ -1,0 +1,3 @@
+updates.pin = [
+  { groupId = "org.scala-lang", artifactId = "scala-library", version = "2.12." }
+]


### PR DESCRIPTION
Configures Scala Steward so it doesn't update the minor Scala version (so that https://github.com/sbt/sbt-multi-jvm/pull/69 doesn't happen)