### PR TITLE
Add macos-latest and windows-latest to CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,11 +22,24 @@ jobs:
     name: Build and Test
     strategy:
       matrix:
-        os: [ubuntu-latest]
+        os: [ubuntu-latest, macos-latest, windows-latest]
         scala: [2.12.18]
         java: [temurin@8, temurin@11, temurin@17, temurin@21]
     runs-on: ${{ matrix.os }}
     steps:
+      - name: Ignore line ending differences in git
+        if: contains(runner.os, 'windows')
+        shell: bash
+        run: git config --global core.autocrlf false
+
+      - name: Configure pagefile for Windows
+        if: contains(runner.os, 'windows')
+        uses: al-cheb/configure-pagefile-action@v1.3
+        with:
+          minimum-size: 2GB
+          maximum-size: 8GB
+          disk-root: 'C:'
+
       - name: Checkout current branch (full)
         uses: actions/checkout@v4
         with:
@@ -65,11 +78,14 @@ jobs:
           cache: sbt
 
       - name: Check that workflows are up to date
+        shell: bash
         run: sbt '++ ${{ matrix.scala }}' githubWorkflowCheck
 
-      - run: sbt '++ ${{ matrix.scala }}' test scripted
+      - shell: bash
+        run: sbt '++ ${{ matrix.scala }}' test scripted
 
       - name: Compress target directories
+        shell: bash
         run: tar cf targets.tar target project/target
 
       - name: Upload target directories
@@ -89,6 +105,18 @@ jobs:
         java: [temurin@8]
     runs-on: ${{ matrix.os }}
     steps:
+      - name: Ignore line ending differences in git
+        if: contains(runner.os, 'windows')
+        run: git config --global core.autocrlf false
+
+      - name: Configure pagefile for Windows
+        if: contains(runner.os, 'windows')
+        uses: al-cheb/configure-pagefile-action@v1.3
+        with:
+          minimum-size: 2GB
+          maximum-size: 8GB
+          disk-root: 'C:'
+
       - name: Checkout current branch (full)
         uses: actions/checkout@v4
         with:

--- a/build.sbt
+++ b/build.sbt
@@ -71,7 +71,7 @@ ThisBuild / githubWorkflowPublish := Seq(
   )
 )
 
-ThisBuild / githubWorkflowOSes := Seq("ubuntu-latest")
+ThisBuild / githubWorkflowOSes := Seq("ubuntu-latest", "macos-latest", "windows-latest")
 
 ThisBuild / githubWorkflowJavaVersions := Seq(
   JavaSpec.temurin("8"),


### PR DESCRIPTION
Seeing as we have already had cases where regressions were created in sbt community plugins for platforms like windows this PR adds mac/windows to the CI.