### PR TITLE
Enable Scala2 inliner

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -34,7 +34,9 @@ scalacOptions ++= List(
   "-deprecation",
   "-language:_",
   "-encoding",
-  "UTF-8"
+  "UTF-8",
+  "-opt-inline-from:<sources>",
+  "-opt:l:inline"
 )
 
 // publish settings


### PR DESCRIPTION
Not expecting a massive difference but its free lunch (i.e. free performance) so there is no reason not to use it.