### PR TITLE
Add sbt 2 support via cross-build with sbt 1

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,11 +23,8 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
-        scala: [2.12.21]
-        java: [temurin@8, temurin@11, temurin@17, temurin@21]
-        exclude:
-          - java: temurin@8
-            os: macos-latest
+        scala: [3.8.4, 2.12.21]
+        java: [temurin@17, temurin@21]
     runs-on: ${{ matrix.os }}
     steps:
       - name: Ignore line ending differences in git
@@ -47,22 +44,6 @@ jobs:
         uses: actions/checkout@v7
         with:
           fetch-depth: 0
-
-      - name: Setup Java (temurin@8)
-        if: matrix.java == 'temurin@8'
-        uses: actions/setup-java@v5
-        with:
-          distribution: temurin
-          java-version: 8
-          cache: sbt
-
-      - name: Setup Java (temurin@11)
-        if: matrix.java == 'temurin@11'
-        uses: actions/setup-java@v5
-        with:
-          distribution: temurin
-          java-version: 11
-          cache: sbt
 
       - name: Setup Java (temurin@17)
         if: matrix.java == 'temurin@17'
@@ -92,7 +73,7 @@ jobs:
 
       - name: Compress target directories
         shell: bash
-        run: tar cf targets.tar target project/target
+        run: tar cf targets.tar target/out/jvm/scala-3.8.4/sbt-multi-jvm project/target
 
       - name: Upload target directories
         uses: actions/upload-artifact@v7
@@ -107,8 +88,8 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest]
-        scala: [2.12.21]
-        java: [temurin@8]
+        scala: [3.8.4]
+        java: [temurin@17]
     runs-on: ${{ matrix.os }}
     steps:
       - name: Ignore line ending differences in git
@@ -128,22 +109,6 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: Setup Java (temurin@8)
-        if: matrix.java == 'temurin@8'
-        uses: actions/setup-java@v5
-        with:
-          distribution: temurin
-          java-version: 8
-          cache: sbt
-
-      - name: Setup Java (temurin@11)
-        if: matrix.java == 'temurin@11'
-        uses: actions/setup-java@v5
-        with:
-          distribution: temurin
-          java-version: 11
-          cache: sbt
-
       - name: Setup Java (temurin@17)
         if: matrix.java == 'temurin@17'
         uses: actions/setup-java@v5
@@ -162,6 +127,16 @@ jobs:
 
       - name: Setup sbt
         uses: sbt/setup-sbt@v1
+
+      - name: Download target directories (3.8.4)
+        uses: actions/download-artifact@v8
+        with:
+          name: target-${{ matrix.os }}-3.8.4-${{ matrix.java }}
+
+      - name: Inflate target directories (3.8.4)
+        run: |
+          tar xf targets.tar
+          rm targets.tar
 
       - name: Download target directories (2.12.21)
         uses: actions/download-artifact@v8

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,7 +23,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
-        scala: [3.8.4, 2.12.21]
+        scala: [2.12.21, 3.8.4]
         java: [temurin@17, temurin@21]
     runs-on: ${{ matrix.os }}
     steps:
@@ -71,16 +71,6 @@ jobs:
       - shell: bash
         run: sbt '++ ${{ matrix.scala }}; test; scripted'
 
-      - name: Compress target directories
-        shell: bash
-        run: tar cf targets.tar target/out/jvm/scala-3.8.4/sbt-multi-jvm project/target
-
-      - name: Upload target directories
-        uses: actions/upload-artifact@v7
-        with:
-          name: target-${{ matrix.os }}-${{ matrix.scala }}-${{ matrix.java }}
-          path: targets.tar
-
   publish:
     name: Publish Artifacts
     needs: [build]
@@ -88,7 +78,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest]
-        scala: [3.8.4]
+        scala: [2.12.21]
         java: [temurin@17]
     runs-on: ${{ matrix.os }}
     steps:
@@ -127,26 +117,6 @@ jobs:
 
       - name: Setup sbt
         uses: sbt/setup-sbt@v1
-
-      - name: Download target directories (3.8.4)
-        uses: actions/download-artifact@v8
-        with:
-          name: target-${{ matrix.os }}-3.8.4-${{ matrix.java }}
-
-      - name: Inflate target directories (3.8.4)
-        run: |
-          tar xf targets.tar
-          rm targets.tar
-
-      - name: Download target directories (2.12.21)
-        uses: actions/download-artifact@v8
-        with:
-          name: target-${{ matrix.os }}-2.12.21-${{ matrix.java }}
-
-      - name: Inflate target directories (2.12.21)
-        run: |
-          tar xf targets.tar
-          rm targets.tar
 
       - name: Publish project
         env:

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 [![Continuous Integration](https://github.com/sbt/sbt-multi-jvm/actions/workflows/ci.yml/badge.svg)](https://github.com/sbt/sbt-multi-jvm/actions/workflows/ci.yml)
 [![Repository size](https://img.shields.io/github/repo-size/sbt/sbt-multi-jvm.svg?logo=git)](https://github.com/sbt/sbt-multi-jvm)
 
-A [sbt] plugin for running scalatest tests in multiple JVMs. This plugin requires sbt 1.9.7 or higher
+A [sbt] plugin for running scalatest tests in multiple JVMs. This plugin supports sbt 1 (1.9.7 or higher) and sbt 2 (2.0.0 or higher); the same artifact coordinates resolve the correct build for each.
 
 [sbt]: http://www.scala-sbt.org
 
@@ -11,7 +11,7 @@ A [sbt] plugin for running scalatest tests in multiple JVMs. This plugin require
 
 To use the plugin in a project add the following to `project/plugins.sbt`:
 
-    addSbtPlugin("com.github.sbt" % "sbt-multi-jvm" % "0.6.0")
+    addSbtPlugin("com.github.sbt" % "sbt-multi-jvm" % "1.0.0")
 
 ## More information
 

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ A [sbt] plugin for running scalatest tests in multiple JVMs. This plugin support
 
 To use the plugin in a project add the following to `project/plugins.sbt`:
 
-    addSbtPlugin("com.github.sbt" % "sbt-multi-jvm" % "1.0.0")
+    addSbtPlugin("com.github.sbt" % "sbt-multi-jvm" % "0.7.0")
 
 ## More information
 

--- a/build.sbt
+++ b/build.sbt
@@ -10,14 +10,17 @@ Global / onLoad := (Global / onLoad).value.andThen { s =>
 }
 
 lazy val scala212 = "2.12.21"
-ThisBuild / crossScalaVersions := Seq(scala212)
-ThisBuild / scalaVersion := scala212
+lazy val scala3 = "3.8.4" // Scala version used by the sbt 2 metabuild
+// Cross-build for sbt 2 (Scala 3) and sbt 1 (Scala 2.12)
+ThisBuild / crossScalaVersions := Seq(scala3, scala212)
+ThisBuild / scalaVersion := scala3
 organization := "com.github.sbt"
 name := "sbt-multi-jvm"
 enablePlugins(SbtPlugin)
 pluginCrossBuild / sbtVersion := {
   scalaBinaryVersion.value match {
-    case "2.12" => "1.9.7" // set minimum sbt version
+    case "2.12" => "1.9.7" // set minimum sbt 1 version
+    case _      => "2.0.0" // sbt 2
   }
 }
 
@@ -27,17 +30,27 @@ libraryDependencies += Defaults.sbtPluginExtra(
   (pluginCrossBuild / sbtBinaryVersion).value,
   (pluginCrossBuild / scalaBinaryVersion).value
 )
+// Cross-build compatibility shims (FileRef / classpath / Tests API) for sbt 1 + sbt 2
+libraryDependencies += Defaults.sbtPluginExtra(
+  "com.github.sbt" % "sbt2-compat" % "0.1.0",
+  (pluginCrossBuild / sbtBinaryVersion).value,
+  (pluginCrossBuild / scalaBinaryVersion).value
+)
 
 // compile settings
 scalacOptions ++= List(
   "-unchecked",
   "-deprecation",
-  "-language:_",
   "-encoding",
-  "UTF-8",
-  "-opt-inline-from:<sources>",
-  "-opt:l:inline"
+  "UTF-8"
 )
+// Scala 2.12-only optimizer / language flags
+scalacOptions ++= {
+  if (scalaBinaryVersion.value == "2.12")
+    List("-language:_", "-opt-inline-from:<sources>", "-opt:l:inline")
+  else
+    Nil
+}
 
 // publish settings
 licenses += "Apache-2.0" -> url("http://www.apache.org/licenses/LICENSE-2.0.html")
@@ -72,11 +85,8 @@ ThisBuild / githubWorkflowPublish := Seq(
 
 ThisBuild / githubWorkflowOSes := Seq("ubuntu-latest", "macos-latest", "windows-latest")
 
+// sbt 2 requires JDK 17+
 ThisBuild / githubWorkflowJavaVersions := Seq(
-  JavaSpec.temurin("8"),
-  JavaSpec.temurin("11"),
   JavaSpec.temurin("17"),
   JavaSpec.temurin("21")
 )
-
-ThisBuild / githubWorkflowBuildMatrixExclusions += MatrixExclude(Map("java" -> "temurin@8", "os" -> "macos-latest"))

--- a/build.sbt
+++ b/build.sbt
@@ -52,6 +52,10 @@ scalacOptions ++= {
     Nil
 }
 
+// scripted: expose the plugin version to test builds and show forked output
+scriptedLaunchOpts ++= Seq("-Xmx1024M", "-Dplugin.version=" + version.value)
+scriptedBufferLog := false
+
 // publish settings
 licenses += "Apache-2.0" -> url("http://www.apache.org/licenses/LICENSE-2.0.html")
 

--- a/build.sbt
+++ b/build.sbt
@@ -47,7 +47,7 @@ scalacOptions ++= List(
 // Scala 2.12-only optimizer / language flags
 scalacOptions ++= {
   if (scalaBinaryVersion.value == "2.12")
-    List("-language:_", "-Xsource:3", "-opt-inline-from:<sources>", "-opt:l:inline")
+    List("-language:_", "-Xsource:3", "-release:8", "-opt-inline-from:<sources>", "-opt:l:inline")
   else
     Nil
 }

--- a/build.sbt
+++ b/build.sbt
@@ -12,8 +12,8 @@ Global / onLoad := (Global / onLoad).value.andThen { s =>
 lazy val scala212 = "2.12.21"
 lazy val scala3 = "3.8.4" // Scala version used by the sbt 2 metabuild
 // Cross-build for sbt 2 (Scala 3) and sbt 1 (Scala 2.12)
-ThisBuild / crossScalaVersions := Seq(scala3, scala212)
-ThisBuild / scalaVersion := scala3
+ThisBuild / crossScalaVersions := Seq(scala212, scala3)
+ThisBuild / scalaVersion := scala212
 organization := "com.github.sbt"
 name := "sbt-multi-jvm"
 enablePlugins(SbtPlugin)
@@ -47,7 +47,7 @@ scalacOptions ++= List(
 // Scala 2.12-only optimizer / language flags
 scalacOptions ++= {
   if (scalaBinaryVersion.value == "2.12")
-    List("-language:_", "-opt-inline-from:<sources>", "-opt:l:inline")
+    List("-language:_", "-Xsource:3", "-opt-inline-from:<sources>", "-opt:l:inline")
   else
     Nil
 }
@@ -67,6 +67,7 @@ developers += Developer(
 )
 
 ThisBuild / githubWorkflowBuild := Seq(WorkflowStep.Sbt(List("test", "scripted")))
+ThisBuild / githubWorkflowArtifactUpload := false
 
 ThisBuild / githubWorkflowTargetTags ++= Seq("v*")
 ThisBuild / githubWorkflowPublishTargetBranches :=

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.12.13
+sbt.version=2.0.0

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,3 +1,5 @@
-addSbtPlugin("com.github.sbt" % "sbt-github-actions" % "0.31.0")
-addSbtPlugin("com.github.sbt" % "sbt-ci-release"     % "1.11.2")
-addSbtPlugin("org.scalameta"  % "sbt-scalafmt"       % "2.6.1")
+// sbt 2 metabuild plugins (Scala 3). Referenced by their fully-resolved
+// `_sbt2_3` artifact names since the metabuild always runs under sbt 2.0.0.
+libraryDependencies += "com.github.sbt" % "sbt-github-actions_sbt2_3" % "0.30.0"
+libraryDependencies += "com.github.sbt" % "sbt-ci-release_sbt2_3"     % "1.11.2"
+libraryDependencies += "org.scalameta"  % "sbt-scalafmt_sbt2_3"       % "2.6.1"

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,5 +1,3 @@
-// sbt 2 metabuild plugins (Scala 3). Referenced by their fully-resolved
-// `_sbt2_3` artifact names since the metabuild always runs under sbt 2.0.0.
-libraryDependencies += "com.github.sbt" % "sbt-github-actions_sbt2_3" % "0.30.0"
-libraryDependencies += "com.github.sbt" % "sbt-ci-release_sbt2_3"     % "1.11.2"
-libraryDependencies += "org.scalameta"  % "sbt-scalafmt_sbt2_3"       % "2.6.1"
+addSbtPlugin("com.github.sbt" % "sbt-github-actions" % "0.30.0")
+addSbtPlugin("com.github.sbt" % "sbt-ci-release"     % "1.11.2")
+addSbtPlugin("org.scalameta"  % "sbt-scalafmt"       % "2.6.1")

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,3 +1,3 @@
-addSbtPlugin("com.github.sbt" % "sbt-github-actions" % "0.30.0")
+addSbtPlugin("com.github.sbt" % "sbt-github-actions" % "0.31.0")
 addSbtPlugin("com.github.sbt" % "sbt-ci-release"     % "1.11.2")
 addSbtPlugin("org.scalameta"  % "sbt-scalafmt"       % "2.6.1")

--- a/src/main/scala-2.12/com/typesafe/sbt/compat/Caching.scala
+++ b/src/main/scala-2.12/com/typesafe/sbt/compat/Caching.scala
@@ -1,3 +1,7 @@
+/**
+ * Copyright (C) 2011-2012 Typesafe Inc. <http://www.typesafe.com>
+ */
+
 package com.typesafe.sbt.compat
 
 /**

--- a/src/main/scala-2.12/com/typesafe/sbt/compat/Caching.scala
+++ b/src/main/scala-2.12/com/typesafe/sbt/compat/Caching.scala
@@ -1,0 +1,9 @@
+package com.typesafe.sbt.compat
+
+/**
+ * sbt 1 has no task caching, so `uncached` is the identity. The matching sbt 2
+ * implementation in `src/main/scala-3` delegates to `Def.uncached`.
+ */
+object Caching {
+  def uncached[A](a: A): A = a
+}

--- a/src/main/scala-2.12/com/typesafe/sbt/compat/Caching.scala
+++ b/src/main/scala-2.12/com/typesafe/sbt/compat/Caching.scala
@@ -5,8 +5,8 @@
 package com.typesafe.sbt.compat
 
 /**
- * sbt 1 has no task caching, so `uncached` is the identity. The matching sbt 2
- * implementation in `src/main/scala-3` delegates to `Def.uncached`.
+ * sbt 1 has no task caching, so `uncached` is the identity. The matching sbt 2 implementation in `src/main/scala-3`
+ * delegates to `Def.uncached`.
  */
 object Caching {
   def uncached[A](a: A): A = a

--- a/src/main/scala-3/com/typesafe/sbt/compat/Caching.scala
+++ b/src/main/scala-3/com/typesafe/sbt/compat/Caching.scala
@@ -1,11 +1,14 @@
+/**
+ * Copyright (C) 2011-2012 Typesafe Inc. <http://www.typesafe.com>
+ */
+
 package com.typesafe.sbt.compat
 
 import sbt.Def
 
 /**
- * sbt 2 caches every task by default and requires a `JsonFormat` for the task's
- * inputs/result. Tasks whose values are not serializable (functions, `Options`,
- * `Tests.Output`, classpaths, forked-JVM results) opt out via `Def.uncached`.
+ * sbt 2 caches every task by default and requires a `JsonFormat` for the task's inputs/result. Tasks whose values are
+ * not serializable (functions, `Options`, `Tests.Output`, classpaths, forked-JVM results) opt out via `Def.uncached`.
  */
 object Caching {
   inline def uncached[A](inline a: A): A = Def.uncached(a)

--- a/src/main/scala-3/com/typesafe/sbt/compat/Caching.scala
+++ b/src/main/scala-3/com/typesafe/sbt/compat/Caching.scala
@@ -1,0 +1,12 @@
+package com.typesafe.sbt.compat
+
+import sbt.Def
+
+/**
+ * sbt 2 caches every task by default and requires a `JsonFormat` for the task's
+ * inputs/result. Tasks whose values are not serializable (functions, `Options`,
+ * `Tests.Output`, classpaths, forked-JVM results) opt out via `Def.uncached`.
+ */
+object Caching {
+  inline def uncached[A](inline a: A): A = Def.uncached(a)
+}

--- a/src/main/scala/com/typesafe/sbt/MultiJvmPlugin.scala
+++ b/src/main/scala/com/typesafe/sbt/MultiJvmPlugin.scala
@@ -7,6 +7,7 @@ package com.typesafe.sbt
 import com.typesafe.sbt.multijvm.{ Jvm, JvmLogger }
 import sbt.*
 import Keys.*
+import sbt.MultiJvmCompat.MultiJvmTestOutput
 import java.io.File
 import java.lang.Boolean.getBoolean
 
@@ -16,6 +17,8 @@ import sbtassembly.AssemblyPlugin.assemblySettings
 import sbtassembly.{ MergeStrategy, AssemblyKeys }
 import sjsonnew.BasicJsonProtocol.*
 import AssemblyKeys.*
+import sbtcompat.PluginCompat
+import com.typesafe.sbt.compat.Caching.uncached
 
 object MultiJvmPlugin extends AutoPlugin {
 
@@ -59,7 +62,7 @@ object MultiJvmPlugin extends AutoPlugin {
     lazy val multiJvmTestJarName = TaskKey[String]("multi-jvm-test-jar-name")
 
     lazy val multiNodeTest = TaskKey[Unit]("multi-node-test")
-    lazy val multiNodeExecuteTests = TaskKey[Tests.Output]("multi-node-execute-tests")
+    lazy val multiNodeExecuteTests = TaskKey[MultiJvmTestOutput]("multi-node-execute-tests")
     lazy val multiNodeTestOnly = InputKey[Unit]("multi-node-test-only")
 
     lazy val multiNodeHosts = SettingKey[Seq[String]]("multi-node-hosts")
@@ -82,47 +85,64 @@ object MultiJvmPlugin extends AutoPlugin {
 
   override lazy val projectSettings = multiJvmSettings
 
-  private[this] def noTestsMessage(scoped: ScopedKey[?])(implicit display: Show[ScopedKey[?]]): String =
-    "No tests to run for " + display.show(scoped)
+  private def noTestsMessage(scoped: ScopedKey[?]): String =
+    "No tests to run for " + scoped.key.label
 
   lazy val multiJvmSettings: Seq[Def.Setting[?]] =
     inConfig(MultiJvm)(Defaults.configSettings ++ internalMultiJvmSettings)
 
   // https://github.com/sbt/sbt/blob/v0.13.15/main/actions/src/main/scala/sbt/Tests.scala#L296-L298
-  private[this] def showResults(log: Logger, results: Tests.Output, noTestsMessage: => String): Unit =
+  private def showResults(log: Logger, results: MultiJvmTestOutput, noTestsMessage: => String): TestResult = {
     TestResultLogger.Default
       .copy(printNoTests = TestResultLogger.const(_ info noTestsMessage))
       .run(log, results, "")
+    results.overall
+  }
 
   private lazy val internalMultiJvmSettings = assemblySettings ++ Seq(
     multiJvmMarker := "MultiJvm",
-    loadedTestFrameworks := (Test / loadedTestFrameworks).value,
-    definedTests := Defaults.detectTests.value,
-    multiJvmTests := collectMultiJvm(definedTests.value.map(_.name), multiJvmMarker.value),
+    loadedTestFrameworks := uncached((Test / loadedTestFrameworks).value),
+    // Discovery tasks depend on freshly compiled classes; sbt 2's task cache key
+    // does not capture that, so keep them uncached to match sbt 1 behavior.
+    definedTests := uncached(Defaults.detectTests.value),
+    multiJvmTests := uncached(collectMultiJvm(definedTests.value.map(_.name), multiJvmMarker.value)),
     multiJvmTestNames := (multiJvmTests.map(_.keys.toSeq) storeAs multiJvmTestNames triggeredBy compile).value,
-    multiJvmApps := collectMultiJvm(discoveredMainClasses.value, multiJvmMarker.value),
+    multiJvmApps := uncached(collectMultiJvm(discoveredMainClasses.value, multiJvmMarker.value)),
     multiJvmAppNames := (multiJvmApps.map(_.keys.toSeq) storeAs multiJvmAppNames triggeredBy compile).value,
-    multiJvmJavaCommand := javaCommand(javaHome.value, "java"),
+    multiJvmJavaCommand := uncached(javaCommand(javaHome.value, "java")),
     jvmOptions := Seq.empty,
     extraOptions := { (_: String) => Seq.empty },
-    multiJvmCreateLogger := { (name: String) => new JvmLogger(name) },
+    multiJvmCreateLogger := uncached { (name: String) => new JvmLogger(name) },
     scalatestRunner := "org.scalatest.tools.Runner",
     scalatestOptions := defaultScalatestOptions,
-    scalatestClasspath := managedClasspath.value.filter(_.data.name.contains("scalatest")),
+    scalatestClasspath := uncached {
+      implicit val conv: xsbti.FileConverter = fileConverter.value
+      managedClasspath.value.filter(entry => PluginCompat.toFile(entry).getName.contains("scalatest"))
+    },
     multiRunCopiedClassLocation := new File(target.value, "multi-run-copied-libraries"),
-    scalatestScalaOptions := scalaOptionsForScalatest(
-      scalatestRunner.value,
-      scalatestOptions.value,
-      fullClasspath.value,
-      multiRunCopiedClassLocation.value
+    scalatestScalaOptions := uncached {
+      implicit val conv: xsbti.FileConverter = fileConverter.value
+      scalaOptionsForScalatest(
+        scalatestRunner.value,
+        scalatestOptions.value,
+        PluginCompat.toFiles(fullClasspath.value),
+        multiRunCopiedClassLocation.value
+      )
+    },
+    scalatestMultiNodeScalaOptions := uncached(
+      scalaMultiNodeOptionsForScalatest(scalatestRunner.value, scalatestOptions.value)
     ),
-    scalatestMultiNodeScalaOptions := scalaMultiNodeOptionsForScalatest(scalatestRunner.value, scalatestOptions.value),
-    multiTestOptions := Options(jvmOptions.value, extraOptions.value, scalatestScalaOptions.value),
-    multiNodeTestOptions := Options(jvmOptions.value, extraOptions.value, scalatestMultiNodeScalaOptions.value),
-    appScalaOptions := scalaOptionsForApps(fullClasspath.value),
+    multiTestOptions := uncached(Options(jvmOptions.value, extraOptions.value, scalatestScalaOptions.value)),
+    multiNodeTestOptions := uncached(
+      Options(jvmOptions.value, extraOptions.value, scalatestMultiNodeScalaOptions.value)
+    ),
+    appScalaOptions := uncached {
+      implicit val conv: xsbti.FileConverter = fileConverter.value
+      scalaOptionsForApps(PluginCompat.toFiles(fullClasspath.value))
+    },
     connectInput := true,
-    multiRunOptions := Options(jvmOptions.value, extraOptions.value, appScalaOptions.value),
-    executeTests := multiJvmExecuteTests.value,
+    multiRunOptions := uncached(Options(jvmOptions.value, extraOptions.value, appScalaOptions.value)),
+    executeTests := uncached(multiJvmExecuteTests.value),
     testOnly := multiJvmTestOnly.evaluated,
     test := showResults(streams.value.log, executeTests.value, "No tests to run for MultiJvm"),
     run := multiJvmRun.evaluated,
@@ -131,19 +151,22 @@ object MultiJvmPlugin extends AutoPlugin {
     // TODO try to make sure that this is only generated on a need to have basis
     multiJvmTestJar := (assembly / assemblyOutputPath).map(_.getAbsolutePath).dependsOn(assembly).value,
     multiJvmTestJarName := (assembly / assemblyOutputPath).value.getAbsolutePath,
-    multiNodeTest := {
-      implicit val display = Project.showContextKey(state.value)
+    multiNodeTest := uncached {
       showResults(streams.value.log, multiNodeExecuteTests.value, noTestsMessage(resolvedScoped.value))
+      ()
     },
-    multiNodeExecuteTests := multiNodeExecuteTestsTask.value,
+    multiNodeExecuteTests := uncached(multiNodeExecuteTestsTask.value),
     multiNodeTestOnly := multiNodeTestOnlyTask.evaluated,
     multiNodeHosts := Seq.empty,
     multiNodeHostsFileName := "multi-node-test.hosts",
-    multiNodeProcessedHosts := processMultiNodeHosts(
-      multiNodeHosts.value,
-      multiNodeHostsFileName.value,
-      multiNodeJavaName.value,
-      streams.value
+    // reads the hosts file from disk (state not captured by the cache key)
+    multiNodeProcessedHosts := uncached(
+      processMultiNodeHosts(
+        multiNodeHosts.value,
+        multiNodeHostsFileName.value,
+        multiNodeJavaName.value,
+        streams.value
+      )
     ),
     multiNodeTargetDirName := "multi-node-test",
     multiNodeJavaName := "java",
@@ -152,10 +175,10 @@ object MultiJvmPlugin extends AutoPlugin {
 
     // here follows the assembly parts of the config
     // don't run the tests when creating the assembly
-    assembly / test := {},
+    assembly / test := Tests.overall(Nil),
 
     // we want everything including the tests and test frameworks
-    assembly / fullClasspath := (MultiJvm / fullClasspath).value,
+    assembly / fullClasspath := uncached((MultiJvm / fullClasspath).value),
 
     // the first class wins just like a classpath
     // just concatenate conflicting text files
@@ -195,18 +218,19 @@ object MultiJvmPlugin extends AutoPlugin {
   def scalaOptionsForScalatest(
       runner: String,
       options: Seq[String],
-      fullClasspath: Classpath,
+      fullClasspath: Seq[File],
       multiRunCopiedClassDir: File
   ): String => Seq[String] = {
-    val directoryBasedClasspathEntries = fullClasspath.files.filter(_.isDirectory)
+    val directoryBasedClasspathEntries = fullClasspath.filter(_.isDirectory)
     // Copy over just the jars to this folder.
-    fullClasspath.files
+    fullClasspath
       .filter(_.isFile)
       .foreach(classpathFile =>
         IO.copyFile(classpathFile, new File(multiRunCopiedClassDir, classpathFile.getName), true)
       )
     val cp =
-      directoryBasedClasspathEntries.absString + File.pathSeparator + multiRunCopiedClassDir.getAbsolutePath + File.separator + "*"
+      directoryBasedClasspathEntries.map(_.getAbsolutePath).mkString(File.pathSeparator) +
+        File.pathSeparator + multiRunCopiedClassDir.getAbsolutePath + File.separator + "*"
     (testClass: String) => { Seq("-cp", cp, runner, "-s", testClass) ++ options }
   }
 
@@ -215,12 +239,12 @@ object MultiJvmPlugin extends AutoPlugin {
       { Seq(runner, "-s", testClass) ++ options }
   }
 
-  def scalaOptionsForApps(classpath: Classpath): String => Seq[String] = {
-    val cp = classpath.files.absString
+  def scalaOptionsForApps(classpath: Seq[File]): String => Seq[String] = {
+    val cp = classpath.map(_.getAbsolutePath).mkString(File.pathSeparator)
     (mainClass: String) => Seq("-cp", cp, mainClass)
   }
 
-  lazy val multiJvmExecuteTests: Def.Initialize[sbt.Task[Tests.Output]] = Def.task {
+  lazy val multiJvmExecuteTests: Def.Initialize[sbt.Task[MultiJvmTestOutput]] = Def.task {
     runMultiJvmTests(
       multiJvmTests.value,
       multiJvmMarker.value,
@@ -232,7 +256,7 @@ object MultiJvmPlugin extends AutoPlugin {
     )
   }
 
-  lazy val multiJvmTestOnly: Def.Initialize[sbt.InputTask[Unit]] = InputTask.createDyn(
+  lazy val multiJvmTestOnly: Def.Initialize[sbt.InputTask[TestResult]] = InputTask.createDyn(
     loadForParser(multiJvmTestNames)((s, i) => Defaults.testOnlyParser(s, i getOrElse Nil))
   ) {
     Def.task { case (selection, _extraOptions) =>
@@ -240,7 +264,7 @@ object MultiJvmPlugin extends AutoPlugin {
       val options = multiTestOptions.value
       val opts = options.copy(extra = (s: String) => { options.extra(s) ++ _extraOptions })
       val filters = selection.map(GlobFilter(_))
-      val tests = multiJvmTests.value.filterKeys(name => filters.exists(_.accept(name)))
+      val tests = multiJvmTests.value.filter { case (name, _) => filters.exists(_.accept(name)) }
       Def.task {
         val results = runMultiJvmTests(
           tests,
@@ -264,7 +288,7 @@ object MultiJvmPlugin extends AutoPlugin {
       srcDir: File,
       createLogger: String => Logger,
       log: Logger
-  ): Tests.Output = {
+  ): MultiJvmTestOutput = {
     val results =
       if (tests.isEmpty)
         List()
@@ -272,7 +296,7 @@ object MultiJvmPlugin extends AutoPlugin {
         tests.map { case (_name, classes) =>
           multi(_name, classes, marker, javaBin, options, srcDir, input = false, createLogger, log)
         }
-    Tests.Output(
+    MultiJvmCompat.testOutput(
       Tests.overall(results.map { case (_, testResult) => testResult }),
       Map.empty,
       results.map { case (testClass, _) => Tests.Summary("multi-jvm", testClass) }
@@ -351,7 +375,7 @@ object MultiJvmPlugin extends AutoPlugin {
     (name, if (failures.nonEmpty) TestResult.Failed else TestResult.Passed)
   }
 
-  lazy val multiNodeExecuteTestsTask: Def.Initialize[sbt.Task[Tests.Output]] = Def.task {
+  lazy val multiNodeExecuteTestsTask: Def.Initialize[sbt.Task[MultiJvmTestOutput]] = Def.task {
     val (_jarName, (hostsAndUsers, javas), targetDir) = multiNodeWorkAround.value
     runMultiNodeTests(
       multiJvmTests.value,
@@ -392,6 +416,7 @@ object MultiJvmPlugin extends AutoPlugin {
           s.log
         )
         showResults(s.log, results, "No tests to run for MultiNode")
+        ()
       }
     }
   }
@@ -408,7 +433,7 @@ object MultiJvmPlugin extends AutoPlugin {
       targetDir: String,
       createLogger: String => Logger,
       log: Logger
-  ): Tests.Output = {
+  ): MultiJvmTestOutput = {
     val results =
       if (tests.isEmpty)
         List()
@@ -430,7 +455,7 @@ object MultiJvmPlugin extends AutoPlugin {
             log
           )
         }
-    Tests.Output(
+    MultiJvmCompat.testOutput(
       Tests.overall(results.map { case (_, testResult) => testResult }),
       Map.empty,
       results.map { case (testClass, _) => Tests.Summary("multi-jvm", testClass) }
@@ -552,6 +577,6 @@ object MultiJvmPlugin extends AutoPlugin {
     theHosts.map { x =>
       val elems = x.split(":").toList.take(2).padTo(2, defaultJava)
       (elems(0), elems(1))
-    } unzip
+    }.unzip
   }
 }

--- a/src/main/scala/com/typesafe/sbt/MultiJvmPlugin.scala
+++ b/src/main/scala/com/typesafe/sbt/MultiJvmPlugin.scala
@@ -29,7 +29,7 @@ object MultiJvmPlugin extends AutoPlugin {
   import autoImport.*
 
   trait MultiJvmKeys {
-    lazy val MultiJvm = config("multi-jvm") extend Test
+    lazy val MultiJvm = config("multi-jvm").extend(Test)
 
     lazy val multiJvmMarker = SettingKey[String]("multi-jvm-marker")
 
@@ -94,7 +94,7 @@ object MultiJvmPlugin extends AutoPlugin {
   // https://github.com/sbt/sbt/blob/v0.13.15/main/actions/src/main/scala/sbt/Tests.scala#L296-L298
   private def showResults(log: Logger, results: MultiJvmTestOutput, noTestsMessage: => String): TestResult = {
     TestResultLogger.Default
-      .copy(printNoTests = TestResultLogger.const(_ info noTestsMessage))
+      .copy(printNoTests = TestResultLogger.const(_.info(noTestsMessage)))
       .run(log, results, "")
     results.overall
   }
@@ -106,9 +106,9 @@ object MultiJvmPlugin extends AutoPlugin {
     // does not capture that, so keep them uncached to match sbt 1 behavior.
     definedTests := uncached(Defaults.detectTests.value),
     multiJvmTests := uncached(collectMultiJvm(definedTests.value.map(_.name), multiJvmMarker.value)),
-    multiJvmTestNames := (multiJvmTests.map(_.keys.toSeq) storeAs multiJvmTestNames triggeredBy compile).value,
+    multiJvmTestNames := multiJvmTests.map(_.keys.toSeq).storeAs(multiJvmTestNames).triggeredBy(compile).value,
     multiJvmApps := uncached(collectMultiJvm(discoveredMainClasses.value, multiJvmMarker.value)),
-    multiJvmAppNames := (multiJvmApps.map(_.keys.toSeq) storeAs multiJvmAppNames triggeredBy compile).value,
+    multiJvmAppNames := multiJvmApps.map(_.keys.toSeq).storeAs(multiJvmAppNames).triggeredBy(compile).value,
     multiJvmJavaCommand := uncached(javaCommand(javaHome.value, "java")),
     jvmOptions := Seq.empty,
     extraOptions := { (_: String) => Seq.empty },
@@ -328,7 +328,7 @@ object MultiJvmPlugin extends AutoPlugin {
 
   def runParser: (State, Seq[String]) => complete.Parser[String] = {
     import complete.DefaultParsers.*
-    (_, appClasses) => Space ~> token(NotSpace examples appClasses.toSet)
+    (_, appClasses) => Space ~> token(NotSpace.examples(appClasses.toSet))
   }
 
   def multi(

--- a/src/main/scala/com/typesafe/sbt/multijvm/Jvm.scala
+++ b/src/main/scala/com/typesafe/sbt/multijvm/Jvm.scala
@@ -31,7 +31,7 @@ object Jvm {
    * check if the current operating system is some OS
    */
   def isOS(os: String): Boolean = try {
-    System.getProperty("os.name").toUpperCase startsWith os.toUpperCase
+    System.getProperty("os.name").toUpperCase.startsWith(os.toUpperCase)
   } catch {
     case _: Throwable => false
   }

--- a/src/main/scala/sbt/MultiJvmCompat.scala
+++ b/src/main/scala/sbt/MultiJvmCompat.scala
@@ -1,10 +1,13 @@
+/**
+ * Copyright (C) 2011-2012 Typesafe Inc. <http://www.typesafe.com>
+ */
+
 package sbt
 
 /**
- * Compatibility shim that lives in package `sbt` so it can re-export
- * `Tests.Output`, which became `private[sbt]` in sbt 2. Plugin code outside
- * of package `sbt` can name the test-output type through this public alias.
- * Compiles unchanged against sbt 1 (where `Tests.Output` is public) and sbt 2.
+ * Compatibility shim that lives in package `sbt` so it can re-export `Tests.Output`, which became `private[sbt]` in sbt 2.
+ * Plugin code outside of package `sbt` can name the test-output type through this public alias. Compiles unchanged
+ * against sbt 1 (where `Tests.Output` is public) and sbt 2.
  */
 object MultiJvmCompat {
   type MultiJvmTestOutput = Tests.Output

--- a/src/main/scala/sbt/MultiJvmCompat.scala
+++ b/src/main/scala/sbt/MultiJvmCompat.scala
@@ -1,0 +1,18 @@
+package sbt
+
+/**
+ * Compatibility shim that lives in package `sbt` so it can re-export
+ * `Tests.Output`, which became `private[sbt]` in sbt 2. Plugin code outside
+ * of package `sbt` can name the test-output type through this public alias.
+ * Compiles unchanged against sbt 1 (where `Tests.Output` is public) and sbt 2.
+ */
+object MultiJvmCompat {
+  type MultiJvmTestOutput = Tests.Output
+
+  /** `Tests.Output` and its companion are `private[sbt]` in sbt 2; expose a constructor. */
+  def testOutput(
+      overall: sbt.protocol.testing.TestResult,
+      events: Map[String, SuiteResult],
+      summaries: Iterable[Tests.Summary]
+  ): MultiJvmTestOutput = Tests.Output(overall, events, summaries)
+}

--- a/src/sbt-test/multi-jvm/run/build.sbt
+++ b/src/sbt-test/multi-jvm/run/build.sbt
@@ -1,0 +1,10 @@
+scalaVersion := "2.13.14"
+
+// MultiJvmPlugin is an AutoPlugin: enabling it applies the MultiJvm config and
+// settings, so no manual `.settings(multiJvmSettings)` splat is needed (which
+// keeps this build file syntax-compatible with both sbt 1 and sbt 2).
+enablePlugins(MultiJvmPlugin)
+
+// scalatest goes in Test; MultiJvm extends Test, so it is available to the
+// multi-jvm sources and the test frameworks are loaded from the Test scope.
+libraryDependencies += "org.scalatest" %% "scalatest" % "3.2.19" % Test

--- a/src/sbt-test/multi-jvm/run/project/plugins.sbt
+++ b/src/sbt-test/multi-jvm/run/project/plugins.sbt
@@ -1,0 +1,3 @@
+addSbtPlugin(
+  "com.github.sbt" % "sbt-multi-jvm" % sys.props.getOrElse("plugin.version", sys.error("plugin.version not set"))
+)

--- a/src/sbt-test/multi-jvm/run/src/multi-jvm/scala/Sample.scala
+++ b/src/sbt-test/multi-jvm/run/src/multi-jvm/scala/Sample.scala
@@ -1,0 +1,28 @@
+/**
+ * Copyright (C) 2011-2012 Typesafe Inc. <http://www.typesafe.com>
+ */
+
+import org.scalatest.wordspec.AnyWordSpec
+
+// Each node writes a marker file when its test body actually runs, so the
+// scripted `test` script can assert the JVMs were really forked and executed
+// (not merely that `MultiJvm/test` returned success with nothing to run).
+object Markers {
+  def touch(name: String): Unit = {
+    val f = new java.io.File("target/" + name)
+    f.getParentFile.mkdirs()
+    f.createNewFile()
+  }
+}
+
+class SampleMultiJvmNode1 extends AnyWordSpec {
+  "node1" should {
+    "run" in { Markers.touch("node1.ran") }
+  }
+}
+
+class SampleMultiJvmNode2 extends AnyWordSpec {
+  "node2" should {
+    "run" in { Markers.touch("node2.ran") }
+  }
+}

--- a/src/sbt-test/multi-jvm/run/test
+++ b/src/sbt-test/multi-jvm/run/test
@@ -1,0 +1,7 @@
+# A multi-jvm test forks one JVM per node and runs the test in each.
+> MultiJvm/test
+
+# The marker files prove both node JVMs were actually forked and executed
+# (guards against the test-discovery tasks being served stale/empty from cache).
+$ exists target/node1.ran
+$ exists target/node2.ran


### PR DESCRIPTION
## What

Cross-builds the plugin for **sbt 2 (Scala 3.8.4)** and **sbt 1 (Scala 2.12.21)**
from a single codebase. Existing sbt 1 users are unaffected; the same artifact
coordinates resolve the correct build per consumer sbt version.

## Key changes

- `project/build.properties`: build with sbt 2.0.0; metabuild plugins resolve
  their sbt 2 variants.
- `build.sbt`: `crossScalaVersions` (Scala 3 + 2.12), `pluginCrossBuild/sbtVersion`
  mapping (`2.12 -> 1.9.7`, `3 -> 2.0.0`), add `sbt2-compat`, gate Scala 2-only
  `scalacOptions`.
- Adapt to sbt 2 API changes:
  - `Tests.Output` is now `private[sbt]` → re-exported via a small package-`sbt`
    alias shim (`MultiJvmCompat`).
  - `test`/`testOnly` are now `InputKey[TestResult]`.
  - Classpaths are `FileRef`-based → converted via `sbt2-compat`'s `PluginCompat`.
- **Opt task-discovery and external-state tasks out of sbt 2's task cache**
  (`Def.uncached`, via a version-specific `Caching` shim). Without this, multi-jvm
  test/app discovery returned stale empty results and silently ran nothing — the
  added scripted test guards this.
- CI: require JDK 17+ (drop Java 8/11), as mandated by sbt 2.
- Added a `scripted` test that runs a multi-jvm ScalaTest across two nodes and
  asserts both JVMs actually executed.

## Notes / decisions for maintainers

- Suggest releasing as **1.0.0** (adds sbt 2, keeps sbt 1, build floor moves to
  JDK 17 + sbt 2 tooling).
- `scala3 = "3.8.4"` is pinned to sbt 2.0.0 and must move in lockstep on bumps.

## Testing

- `+compile`, `+scripted`, `scalafmtCheckAll`/`scalafmtSbtCheck`, `githubWorkflowCheck` — all green locally.
- `scripted` passes under **both** sbt 1 and sbt 2.
- Smoke-tested `MultiJvm/test`, `testOnly`, and `run` against local consumer
  projects on both sbt versions.